### PR TITLE
Serial 253, Change DNS server to TalDos (Don't merge yet)

### DIFF
--- a/db.cosi
+++ b/db.cosi
@@ -1,13 +1,13 @@
 $TTL 1h
-@                       IN SOA  talos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                252     ; serial
+@                       IN SOA  taldos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
+                                253     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
                                 1800 )  ; negative caching-ttl
 
 ; Namservers
-@                       IN NS           talos
+@                       IN NS           taldos
 recursion		        IN NS		    bacon
 
 ; 144 subnet
@@ -53,8 +53,8 @@ jesubelle               IN A            128.153.144.123
 
 ; 145 subnet
 ziltoid                 IN A            128.153.145.2
-talos                   IN A            128.153.145.3
-atlas                   IN A            128.153.145.4
+taldos                  IN A            128.153.145.3
+talos                   IN A            128.153.145.4
 bacon                   IN A            128.153.145.10
 mirror                  IN A            128.153.145.19
 f1                      IN A            128.153.145.20
@@ -101,8 +101,8 @@ hnd-dev                 IN A            128.153.146.25
 
 ; IPv6
 ziltoid                 IN AAAA         2605:6480:c051:0002::1
-talos                   IN AAAA         2605:6480:c051:0003::1
-atlas                   IN AAAA         2605:6480:c051:0004::1
+taldos                  IN AAAA         2605:6480:c051:0003::1
+talos                   IN AAAA         2605:6480:c051:0004::1
 bacon                   IN AAAA         2605:6480:c051:0005::1
 unbound                 IN AAAA         2605:6480:c051:0053::1
 mirror                  IN AAAA         2605:6480:c051:0100::1
@@ -111,8 +111,8 @@ c051                    IN AAAA         2605:6480:c051:c051:c051:c051:c051:c051
 norm                    IN AAAA         2605:6480:c051:0303::1
 
 ; CNAMEs
-dns1                    IN CNAME        talos
-dns2                    IN CNAME        atlas
+dns1                    IN CNAME        taldos
+dns2                    IN CNAME        talos
 lapras                  IN CNAME        talos
 radius                  IN CNAME        talos
 
@@ -181,7 +181,7 @@ test                    IN TXT          "HELLO WORLD"
 ; CAA
 @                       IN CAA          128 issue "letsencrypt.org"
 talos                   IN CAA          128 issue "talos.cslabs.clarkson.edu"
-atlas                   IN CAA          128 issue "letsencrypt.org"
+taldos                  IN CAA          128 issue "letsencrypt.org"
 mirror                  IN CAA          128 issue "letsencrypt.org"
 dubsdot                 IN CAA          128 issue "letsencrypt.org"
 library                 IN CAA          128 issue "letsencrypt.org"

--- a/db.cslabs
+++ b/db.cslabs
@@ -1,13 +1,13 @@
 $TTL 1h
-@                       IN SOA  talos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                252     ; serial
+@                       IN SOA  taldos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
+                                253     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
                                 1800 )  ; negative caching-ttl
 
 ; Namservers
-@                       IN NS           talos
+@                       IN NS           taldos
 recursion		        IN NS		    bacon
 
 ; 144 subnet
@@ -53,8 +53,8 @@ jesubelle               IN A            128.153.144.123
 
 ; 145 subnet
 ziltoid                 IN A            128.153.145.2
-talos                   IN A            128.153.145.3
-atlas                   IN A            128.153.145.4
+taldos                  IN A            128.153.145.3
+talos                   IN A            128.153.145.4
 bacon                   IN A            128.153.145.10
 mirror                  IN A            128.153.145.19
 f1                      IN A            128.153.145.20
@@ -102,8 +102,8 @@ hnd-dev                 IN A            128.153.146.25
 
 ; IPv6
 ziltoid                 IN AAAA         2605:6480:c051:0002::1
-talos                   IN AAAA         2605:6480:c051:0003::1
-atlas                   IN AAAA         2605:6480:c051:0004::1
+taldos                  IN AAAA         2605:6480:c051:0003::1
+talos                   IN AAAA         2605:6480:c051:0004::1
 bacon                   IN AAAA         2605:6480:c051:0005::1
 unbound                 IN AAAA         2605:6480:c051:0053::1
 mirror                  IN AAAA         2605:6480:c051:0100::1
@@ -112,8 +112,8 @@ voip6                   IN AAAA         2605:6480:c051:0101::1
 norm                    IN AAAA         2605:6480:c051:0303::1
 
 ; CNAMEs
-dns1                    IN CNAME        talos
-dns2                    IN CNAME        atlas
+dns1                    IN CNAME        taldos
+dns2                    IN CNAME        talos
 lapras                  IN CNAME        talos
 radius                  IN CNAME        talos
 
@@ -181,7 +181,7 @@ test                    IN TXT          "HELLO WORLD"
 ; CAA
 @                       IN CAA          128 issue "letsencrypt.org"
 talos                   IN CAA          128 issue "talos.cslabs.clarkson.edu"
-atlas                   IN CAA          128 issue "letsencrypt.org"
+taldos                  IN CAA          128 issue "letsencrypt.org"
 mirror                  IN CAA          128 issue "letsencrypt.org"
 dubsdot                 IN CAA          128 issue "letsencrypt.org"
 library                 IN CAA          128 issue "letsencrypt.org"

--- a/db.cslabs.rvs.144
+++ b/db.cslabs.rvs.144
@@ -1,13 +1,13 @@
 $TTL 1h
-@                       IN SOA  talos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                252       ; serial
+@                       IN SOA  taldos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
+                                253     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
                                 1800 )  ; negative caching-ttl
 
 ; Nameservers
-@                       IN NS   talos.cslabs.clarkson.edu.
+@                       IN NS   taldos.cslabs.clarkson.edu.
 
 ; Reverse 128.153.144/24
 ; Note: the trailing dots are VERY IMPORTANT!

--- a/db.cslabs.rvs.145
+++ b/db.cslabs.rvs.145
@@ -1,18 +1,18 @@
 $TTL 1h
-@                       IN SOA  talos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                252     ; serial
+@                       IN SOA  taldos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
+                                253     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
                                 1800 )  ; negative caching-ttl
 ; Nameservers
-@                       IN NS   talos.cslabs.clarkson.edu.
+@                       IN NS   taldos.cslabs.clarkson.edu.
 
 ; Reverse 128.153.145/24
 ; Note: the trailing dots are VERY IMPORTANT!
 2                       IN PTR  ziltoid.cslabs.clarkson.edu.
-3                       IN PTR  talos.cslabs.clarkson.edu.
-4                       IN PTR  atlas.cslabs.clarkson.edu.
+3                       IN PTR  taldos.cslabs.clarkson.edu.
+4                       IN PTR  talos.cslabs.clarkson.edu.
 10                      IN PTR  bacon.cslabs.clarkson.edu.
 19                      IN PTR  mirror.cslabs.clarkson.edu.
 20                      IN PTR  f1.cslabs.clarkson.edu.

--- a/db.cslabs.rvs.146
+++ b/db.cslabs.rvs.146
@@ -1,12 +1,12 @@
 $TTL 1h
-@                       IN SOA  talos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                252     ; serial
+@                       IN SOA  taldos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
+                                253     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
                                 1800 )  ; negative caching-ttl
 ; Nameservers
-@                       IN NS   talos.cslabs.clarkson.edu.
+@                       IN NS   taldos.cslabs.clarkson.edu.
 
 ; Reverse 128.153.146/24
 ; Note: the trailing dots are VERY IMPORTANT!

--- a/db.cslabs.rvs.c051
+++ b/db.cslabs.rvs.c051
@@ -1,12 +1,12 @@
 $TTL 1h
-@                       IN SOA  talos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                252     ; serial
+@                       IN SOA  taldos.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
+                                253     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
                                 1800 )  ; negative caching-ttl
 ; Nameservers
-@                       IN NS   talos.cslabs.clarkson.edu.
+@                       IN NS   taldos.cslabs.clarkson.edu.
 
 ; Reverse 2605:6480:c051::/48
 
@@ -15,8 +15,8 @@ $TTL 1h
 
 ; Essential Services
 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0 PTR ziltoid.cslabs.clarkson.edu.
-1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.0 PTR talos.cslabs.clarkson.edu.
-1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.4.0.0.0 PTR atlas.cslabs.clarkson.edu.
+1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.0 PTR taldos.cslabs.clarkson.edu.
+1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.4.0.0.0 PTR talos.cslabs.clarkson.edu.
 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.5.0.0.0 PTR bacon.cslabs.clarkson.edu.
 
 ; Public Services


### PR DESCRIPTION
TalDos now has Talos's IP (to prevent stuff from breaking unexpectedly) 

Talos now has Atlas's IP (to act as a secondary DNS if we wish) 

Relevant records are updated

Please don't merge until changes are tested on TalDos