### PR TITLE
Add jenkins.cosi.clarkson.edu

### DIFF
--- a/db.cosi
+++ b/db.cosi
@@ -74,7 +74,7 @@ caterpillar             IN A            128.153.145.52
 unbound                 IN A            128.153.145.53
 ender                   IN A            128.153.145.54
 koma                    IN A            128.153.145.55
-jenkins                 IN a            128.153.145.67
+jenkins                 IN A            128.153.145.67
 voip                    IN A            128.153.145.80
 materiae                IN A            128.153.145.81
 elephant                IN A            128.153.145.91

--- a/db.cosi
+++ b/db.cosi
@@ -1,6 +1,6 @@
 $TTL 1h
 @                       IN SOA  taltres.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                271     ; serial
+                                272     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
@@ -74,6 +74,7 @@ caterpillar             IN A            128.153.145.52
 unbound                 IN A            128.153.145.53
 ender                   IN A            128.153.145.54
 koma                    IN A            128.153.145.55
+jenkins                 IN a            128.153.145.67
 voip                    IN A            128.153.145.80
 materiae                IN A            128.153.145.81
 elephant                IN A            128.153.145.91

--- a/db.cslabs
+++ b/db.cslabs
@@ -74,7 +74,7 @@ caterpillar             IN A            128.153.145.52
 unbound                 IN A            128.153.145.53
 ender                   IN A            128.153.145.54
 koma                    IN A            128.153.145.55
-jenkins                 IN a            128.153.145.67
+jenkins                 IN A            128.153.145.67
 voip                    IN A            128.153.145.80
 materiae                IN A            128.153.145.81
 elephant                IN A            128.153.145.91

--- a/db.cslabs
+++ b/db.cslabs
@@ -1,6 +1,6 @@
 $TTL 1h
 @                       IN SOA  taltres.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                271     ; serial
+                                272     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
@@ -74,6 +74,7 @@ caterpillar             IN A            128.153.145.52
 unbound                 IN A            128.153.145.53
 ender                   IN A            128.153.145.54
 koma                    IN A            128.153.145.55
+jenkins                 IN a            128.153.145.67
 voip                    IN A            128.153.145.80
 materiae                IN A            128.153.145.81
 elephant                IN A            128.153.145.91

--- a/db.cslabs.rvs.144
+++ b/db.cslabs.rvs.144
@@ -1,6 +1,6 @@
 $TTL 1h
 @                       IN SOA  taltres.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                271     ; serial
+                                272     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire

--- a/db.cslabs.rvs.145
+++ b/db.cslabs.rvs.145
@@ -30,7 +30,7 @@ $TTL 1h
 53                      IN PTR  unbound.cslabs.clarkson.edu.
 54                      IN PTR  ender.cslabs.clarkson.edu.
 55                      IN PTR  koma.cslabs.clarkson.edu.
-67                      IN PTR  jenkins.cslabs.clarkson.edu
+67                      IN PTR  jenkins.cslabs.clarkson.edu.
 80                      IN PTR  voip.cslabs.clarkson.edu.
 81                      IN PTR  materiae.cslabs.clarkson.edu.
 91                      IN PTR  elephant.cslabs.clarkson.edu.

--- a/db.cslabs.rvs.145
+++ b/db.cslabs.rvs.145
@@ -1,6 +1,6 @@
 $TTL 1h
 @                       IN SOA  taltres.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                271     ; serial
+                                272     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire
@@ -30,6 +30,7 @@ $TTL 1h
 53                      IN PTR  unbound.cslabs.clarkson.edu.
 54                      IN PTR  ender.cslabs.clarkson.edu.
 55                      IN PTR  koma.cslabs.clarkson.edu.
+67                      IN PTR  jenkins.cslabs.clarkson.edu
 80                      IN PTR  voip.cslabs.clarkson.edu.
 81                      IN PTR  materiae.cslabs.clarkson.edu.
 91                      IN PTR  elephant.cslabs.clarkson.edu.

--- a/db.cslabs.rvs.146
+++ b/db.cslabs.rvs.146
@@ -1,6 +1,6 @@
 $TTL 1h
 @                       IN SOA  taltres.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                271     ; serial
+                                272     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire

--- a/db.cslabs.rvs.c051
+++ b/db.cslabs.rvs.c051
@@ -1,6 +1,6 @@
 $TTL 1h
 @                       IN SOA  taltres.cslabs.clarkson.edu. root.cslabs.clarkson.edu. (
-                                271     ; serial
+                                272     ; serial
                                 1d      ; refresh
                                 2h      ; retry
                                 1w      ; expire


### PR DESCRIPTION
This adds `jenkins.cosi.clarkson.edu` and `jenkins.cslabs.clarkson.edu` which point to `128.153.145.67` for a Jenkins build server being deployed internally for mirror builds (and hopefully other projects).